### PR TITLE
improve build and run workflow

### DIFF
--- a/Documentation/building.ad
+++ b/Documentation/building.ad
@@ -25,7 +25,7 @@ Install only Python and SCons via your system package manager:
 **macOS:**
 [source,bash]
 ----
-brew install python3 scons
+brew install python scons
 ----
 
 **Debian/Ubuntu:**
@@ -43,14 +43,13 @@ sudo apt-get install -y python3 scons
 * Cross-compiler toolchain builds reliably
 * QEMU and GDB installation straightforward
 
-**macOS (Partial Support):**
+**macOS:**
 
-* i686 builds supported but may require manual setup
+* i686 builds are supported with the managed local toolchain
 * x86_64 and ARM64 builds not fully tested
-* Cross-compiler toolchain building may fail or require manual intervention
-* Consider using Docker or a Linux VM for production builds
-* Manual toolchain installation may be necessary (see <<Troubleshooting>>)
-* Does not support disk image builds because of `parted`
+* ISO image builds are supported through `grub-mkrescue` and `xorriso`
+* Raw `.img` builds require `guestfish`, which is not normally available through Homebrew
+* Use `ImageFormat=iso` on macOS unless you build raw disk images in Linux or a Linux container
 
 == Building the Project
 
@@ -72,10 +71,13 @@ BuildArch = 'i686'
 ImageFs = 'fat32'
 BuildType = 'full'
 ImageSize = '250m'
-toolchain = '../os_toolchain'
 ImageName = 'valeciumos'
 ImageFormat = 'img'
 KernelName = 'valeciumx'
+ToolchainPrefix = 'toolchain'
+RunMemory = '4G'
+RunSmp = '1'
+GdbCommand = 'gdb'
 ----
 
 === Step 1: Install Dependencies
@@ -90,9 +92,16 @@ scons deps
 
 This automatically:
 
-* Detects your architecture and OS
-* Downloads and builds required dependencies
-* Installs QEMU and debugging tools
+* Detects your host OS or Linux distribution
+* Installs host packages for building, image creation, QEMU, debugging, and documentation
+* Uses Homebrew on macOS and the supported distro package manager on Linux
+
+To preview the package command without installing:
+
+[source,bash]
+----
+python3 scripts/base/dependencies.py -n
+----
 
 === Step 2: Building the Toolchain
 
@@ -103,15 +112,29 @@ Once dependencies are installed via `scons deps`, you can build the cross-compil
 scons toolchain
 ----
 
-This builds the cross-compiler for your target architecture based on the `BuildArch` variable in `.config` or if you explicitly set it via arguments. The toolchain build requires dependencies to be installed first. The path that the toolchain will install to is the directory the `toolchain` variable points to (You may need root privillages if you would like to install it system wide to locations like `/opt/cross`).
+This builds the cross-compiler for your target architecture based on the `BuildArch` variable in `.config`, or an explicit command-line override. The toolchain build requires dependencies to be installed first. The default install location is `toolchain/` at the repository root.
+
+To use a different install location:
+
+[source,bash]
+----
+scons ToolchainPrefix=/opt/cross toolchain
+----
 
 === Step 3: Build
 
-Once dependencies are installed and toolchain is built, build normally (make sure that you set the toolchain path to the acctual toolchain path):
+Once dependencies are installed and the toolchain is built, build normally:
 
 [source,bash]
 ----
 scons                    # Build with default settings (debug mode)
+----
+
+On macOS, build an ISO image:
+
+[source,bash]
+----
+scons ImageFormat=iso
 ----
 
 This builds:
@@ -129,6 +152,14 @@ Build artifacts are placed in the `build/` directory.
 scons run                # Boot in QEMU
 # or
 scons debug              # Start debugging session
+----
+
+On macOS with ISO output:
+
+[source,bash]
+----
+scons run ImageFormat=iso
+scons debug ImageFormat=iso
 ----
 
 === Building for Multiple Architectures
@@ -185,6 +216,10 @@ Pass variables to `scons` to customize the build. Common options:
 | `BootType` | `bios`, `efi` | `bios`
 | `DiskPartitionMap` | `mbr`, `gpt` | `mbr`
 | `ImageName` | Base name (no extension) | `valeciumos`
+| `ToolchainPrefix` | Toolchain install prefix | `toolchain`
+| `RunMemory` | QEMU memory size for `run`/`debug` | `4G`
+| `RunSmp` | QEMU CPU count for `run` | `1`
+| `GdbCommand` | Debugger executable for `debug` | `gdb`
 |===
 
 === Examples
@@ -211,6 +246,9 @@ scons ImageSize=512m
 
 # ISO format instead of hard disk
 scons ImageFormat=iso
+
+# Run an ISO with custom QEMU memory
+scons run ImageFormat=iso RunMemory=512M
 
 # EFI image with GPT partition table (x86_64 example)
 scons BuildArch=x86_64 BootType=efi DiskPartitionMap=gpt
@@ -261,7 +299,7 @@ scons BuildType=full
 scons BuildType=kernel
 ----
 
-Output: `build/kernel/valeciumx` (ELF executable with debug symbols)
+Output: `build/<arch>_<config>/kernel/valeciumx-<version>` (ELF executable with debug symbols)
 
 === Userspace Only
 
@@ -293,7 +331,7 @@ scons run
 ----
 
 This starts a QEMU virtual machine with:
-* 32 MB of RAM (configurable)
+* `RunMemory` RAM (`4G` by default)
 * Disk image if available
 * Display output
 
@@ -302,10 +340,13 @@ This starts a QEMU virtual machine with:
 [source,bash]
 ----
 # Increase memory to 64 MB
-scons run -- --memory=64M
+scons run RunMemory=64M
 
-# Use specific output image
-scons run -- --image=build/valeciumos.img
+# Use two virtual CPUs
+scons run RunSmp=2
+
+# Run the ISO image workflow
+scons run ImageFormat=iso
 ----
 
 === Debugging with GDB
@@ -315,6 +356,7 @@ Start a debug session with kernel symbols:
 [source,bash]
 ----
 scons debug
+scons debug GdbCommand=/opt/homebrew/bin/gdb
 ----
 
 This:
@@ -339,20 +381,34 @@ From another terminal, you can set breakpoints and step through code:
 
 SCons caches build results, so subsequent builds only recompile changed files.
 
-=== macOS Toolchain Issues
+=== macOS Toolchain and Image Notes
 
-macOS support for automated toolchain building is limited. If `scons toolchain` fails:
-
-**Option 1: Use Homebrew (easiest, i686 only)**
+The supported macOS workflow is:
 
 [source,bash]
 ----
-brew install gmp mpc mpfr
-
-# include --with-gmp=... --with-mpc=... in your configure command for autoconf to find dependencies
+brew install python scons
+scons deps
+scons toolchain
+scons ImageFormat=iso
+scons run ImageFormat=iso
 ----
 
-**Option 2: Use Docker (recommended for reliable builds)**
+If the toolchain build cannot find Homebrew libraries, confirm that these packages are installed:
+
+[source,bash]
+----
+brew install gcc gmp mpfr libmpc zlib make texinfo
+----
+
+Raw `.img` builds need `guestfish`. If it is unavailable, build an ISO instead:
+
+[source,bash]
+----
+scons ImageFormat=iso
+----
+
+**Linux container fallback:**
 
 [source,bash]
 ----
@@ -360,20 +416,7 @@ docker run -it -v $(pwd):/valecium ubuntu:22.04 bash
 # Inside container:
 apt-get update && apt-get install -y scons python3
 cd /valecium
-scons deps && scons toolchain && scons build
-----
-
-**Option 3: Use a Linux VM (VirtualBox, Parallels)**
-
-Running Valecium OS builds on Linux is more reliable. Consider setting up a development VM.
-
-**Option 4: Manual toolchain installation (advanced)**
-
-Build from source following GNU toolchain documentation, then configure `.config`:
-
-[source,ini]
-----
-toolchain = '/path/to/custom/toolchain'
+scons deps && scons toolchain && scons
 ----
 
 === Cleaning Build Artifacts
@@ -385,15 +428,14 @@ Remove all build artifacts:
 scons -c              # Clean build directory
 ----
 
-== Environment Variables
+== Command-Line Overrides
 
-You can also set build options via environment variables (lower precedence than command-line):
+Pass build options directly to SCons. Command-line values override `.config` for that invocation:
 
 [source,bash]
 ----
-export VALECIUM_ARCH=i686
-export VALECIUM_CONFIG=release
-scons
+scons BuildArch=i686 BuildConfig=release
+scons ToolchainPrefix=/opt/cross BuildType=kernel
 ----
 
 == Advanced Topics
@@ -404,16 +446,16 @@ If your cross-compiler is in a non-standard location:
 
 [source,bash]
 ----
-scons toolchain=/opt/cross/
+scons ToolchainPrefix=/opt/cross/
 ----
 
-=== Verbose Build Output
+=== Build Explanation Output
 
-See detailed compiler commands:
+Ask SCons why targets are being rebuilt:
 
 [source,bash]
 ----
-scons --verbose
+scons --debug=explain
 ----
 
 === Parallel Builds
@@ -455,7 +497,7 @@ Generate documentation in multiple formats (PDF, HTML, man pages, info pages):
 
 [source,bash]
 ----
-cd Documents
+cd Documentation
 make pdf                 # Generate PDF documents
 make html                # Generate HTML documents
 make man                 # Generate man pages

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ This repository contains:
 
 ## Documentation
 
-Primary source docs live in [`Documents/`](Documents/).
+Primary source docs live in [`Documentation/`](Documentation/).
 
-- Project index: [`Documents/index.ad`](Documents/index.ad)
-- Build guide: [`Documents/building.ad`](Documents/building.ad)
-- Development guide and coding conventions: [`Documents/devel.ad`](Documents/devel.ad)
-- Implementation roadmap: [`Documents/roadmap.ad`](Documents/roadmap.ad)
+- Project index: [`Documentation/index.ad`](Documentation/index.ad)
+- Build guide: [`Documentation/building.ad`](Documentation/building.ad)
+- Development guide and coding conventions: [`Documentation/devel.ad`](Documentation/devel.ad)
+- Implementation roadmap: [`Documentation/roadmap.ad`](Documentation/roadmap.ad)
 
 Published docs are available at [docs.vyang.org/valecium](https://docs.vyang.org/valecium/).
 
@@ -28,12 +28,19 @@ Published docs are available at [docs.vyang.org/valecium](https://docs.vyang.org
 
 ### 1. Install host prerequisites
 
-You need Python 3 and SCons.
+You need Python 3, SCons, and your host package manager.
 
-Ubuntu example:
+macOS:
 
 ```bash
-sudo apt install python3 scons
+brew install python scons
+```
+
+Ubuntu/Debian:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3 scons
 ```
 
 ### 2. Install dependencies
@@ -42,13 +49,25 @@ sudo apt install python3 scons
 scons deps
 ```
 
-### 3. Build
+### 3. Build the cross-toolchain
+
+```bash
+scons toolchain
+```
+
+### 4. Build
 
 ```bash
 scons
 ```
 
-### 4. Run or debug
+On macOS, use ISO format unless you have `guestfish` available for raw disk images:
+
+```bash
+scons ImageFormat=iso
+```
+
+### 5. Run or debug
 
 ```bash
 scons run
@@ -56,11 +75,19 @@ scons run
 scons debug
 ```
 
+macOS ISO workflow:
+
+```bash
+scons run ImageFormat=iso
+scons debug ImageFormat=iso
+```
+
 Notes:
 
 - Build settings are persisted in `.config` at repository root (auto-created on first run).
-- Toolchain setup is handled by the build flow (`--ensure`) and is also available explicitly via `scons toolchain`.
-- On macOS, image-building support is limited (notably due to `parted` availability). See [`Documents/building.ad`](Documents/building.ad).
+- Toolchain setup is available explicitly via `scons toolchain`.
+- Raw `.img` builds require `guestfish`; macOS users should usually build and run with `ImageFormat=iso`.
+- For a dependency dry-run, use `python3 scripts/base/dependencies.py -n`.
 
 ## Repository Guide
 
@@ -71,7 +98,7 @@ Top-level directories and what they contain:
 - [`usr/`](usr/) - userspace components and libraries
 - [`image/`](image/) - disk image assembly logic and root image content
 - [`scripts/`](scripts/) - helper scripts for dependencies, toolchain, QEMU, GDB, formatting
-- [`Documents/`](Documents/) - AsciiDoc source for project documentation
+- [`Documentation/`](Documentation/) - AsciiDoc source for project documentation
 
 Important build files:
 
@@ -93,6 +120,10 @@ Common SCons variables:
 - `BootType`: `bios` (default) or `efi`
 - `DiskPartitionMap`: `mbr` (default) or `gpt`
 - `ImageName`: base name of output image
+- `ToolchainPrefix`: cross-toolchain installation prefix (`toolchain` by default)
+- `RunMemory`: memory passed to QEMU run/debug helpers (`4G` by default)
+- `RunSmp`: CPU count passed to `scons run` (`1` by default)
+- `GdbCommand`: debugger executable passed to `scons debug` (`gdb` by default)
 
 Examples:
 
@@ -101,21 +132,22 @@ scons BuildConfig=release
 scons BuildArch=x86_64 BuildConfig=release
 scons BuildType=kernel
 scons ImageFormat=iso
+scons run ImageFormat=iso RunMemory=512M
 scons BootType=efi DiskPartitionMap=gpt BuildArch=x86_64
 ```
 
-For full build and platform notes, read [`Documents/building.ad`](Documents/building.ad).
+For full build and platform notes, read [`Documentation/building.ad`](Documentation/building.ad).
 
 ## Development and Contributing
 
-Start with [`Documents/devel.ad`](Documents/devel.ad), which covers:
+Start with [`Documentation/devel.ad`](Documentation/devel.ad), which covers:
 
 - Build/development workflow
 - Git and patch submission expectations
 - Coding style, naming, and commenting conventions
 - Architecture separation and HAL strategy (no platform-specific assembly in common code)
 
-If you plan a larger feature, check [`Documents/roadmap.ad`](Documents/roadmap.ad) to align with current priorities.
+If you plan a larger feature, check [`Documentation/roadmap.ad`](Documentation/roadmap.ad) to align with current priorities.
 
 ## Project Status
 
@@ -126,7 +158,7 @@ Valecium OS is actively developed. Roadmap highlights include:
 - Filesystem and device capability growth
 - Longer-term advanced features (networking, extended process model)
 
-Track current progress in [`Documents/roadmap.ad`](Documents/roadmap.ad).
+Track current progress in [`Documentation/roadmap.ad`](Documentation/roadmap.ad).
 
 ## Licensing
 

--- a/SConstruct
+++ b/SConstruct
@@ -8,9 +8,12 @@ Main build configuration file using SCons.
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
+from SCons.Action import Action
 from SCons.Environment import Environment
+from SCons.Script import AlwaysBuild, COMMAND_LINE_TARGETS, Exit, GetOption
 from SCons.Variables import EnumVariable, Variables
 
 from scripts.scons.arch import GetArchConfig, GetSupportedArchitectures
@@ -21,6 +24,8 @@ from scripts.scons.bootloader import (
 )
 from scripts.scons.disk import GetSupportedFilesystems, GetSupportedPartitionMaps
 from scripts.scons.utility import ParseSize
+
+SetupOnlyTargets = {'deps', 'toolchain'}
 
 
 def GetGitHash() -> str:
@@ -34,47 +39,6 @@ def GetGitHash() -> str:
         return Result.stdout.strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         return ''
-
-
-def ResolveTools(Arch: str):
-    Prefixes = [f'{Arch}-linux-musl-', f'{Arch}-elf-', '']
-
-    Selected = ''
-    for Prefix in Prefixes:
-        Gcc = f'{Prefix}gcc' if Prefix else 'gcc'
-        if shutil.which(Gcc):
-            Selected = Prefix
-            break
-
-    Bases = {
-        'AS': 'as',
-        'AR': 'ar',
-        'CC': 'gcc',
-        'LD': 'gcc',
-        'RANLIB': 'ranlib',
-        'STRIP': 'strip',
-    }
-
-    Tools = {}
-    Paths = {}
-
-    for Key, Base in Bases.items():
-        Preferred = f'{Selected}{Base}' if Selected else Base
-        PreferredPath = shutil.which(Preferred)
-        if PreferredPath:
-            Tools[Key] = Preferred
-            Paths[Key] = PreferredPath
-            continue
-
-        FallbackPath = shutil.which(Base)
-        if FallbackPath:
-            Tools[Key] = Base
-            Paths[Key] = FallbackPath
-        else:
-            Tools[Key] = Preferred
-            Paths[Key] = '<not found>'
-
-    return Tools, Paths, Selected
 
 
 ConfigPath = Path('.config')
@@ -92,6 +56,10 @@ if not ConfigPath.exists():
         'BootSystem': 'grub',
         'BootType': 'bios',
         'DiskPartitionMap': 'mbr',
+        'ToolchainPrefix': 'toolchain',
+        'RunMemory': '4G',
+        'RunSmp': '1',
+        'GdbCommand': 'gdb',
     }
     with open(ConfigPath, 'w', encoding='utf-8') as CfgFile:
         for Key, Value in DefaultConfig.items():
@@ -155,10 +123,68 @@ Vars.Add('ProjVersion',
          help='Kernel version string in MAJOR.MINOR form',
          default='0.28')
 
+Vars.Add('ToolchainPrefix',
+         help='Cross-toolchain installation prefix',
+         default='toolchain')
+
+Vars.Add('RunMemory',
+         help='Memory size passed to QEMU run/debug helpers',
+         default='4G')
+
+Vars.Add('RunSmp',
+         help='CPU count passed to QEMU run helper',
+         default='1')
+
+Vars.Add('GdbCommand',
+         help='GDB executable used by the debug helper',
+         default='gdb')
+
 Deps = {
     'binutils': '2.45',
     'gcc': '15.2.0',
 }
+
+
+def ResolvePath(PathValue: str) -> Path:
+    Result = Path(str(PathValue)).expanduser()
+    if not Result.is_absolute():
+        Result = Path.cwd() / Result
+    return Result.resolve()
+
+
+def GetHomebrewPrefixes() -> list:
+    Prefixes = []
+    EnvPrefix = os.environ.get('HOMEBREW_PREFIX')
+    if EnvPrefix:
+        Prefixes.append(EnvPrefix)
+    Prefixes.extend(['/opt/homebrew', '/usr/local'])
+
+    UniquePrefixes = []
+    for Prefix in Prefixes:
+        if Prefix not in UniquePrefixes:
+            UniquePrefixes.append(Prefix)
+    return UniquePrefixes
+
+
+def AddHostToolPaths(Env):
+    for Prefix in reversed(GetHomebrewPrefixes()):
+        Env.PrependENVPath('PATH', os.path.join(Prefix, 'opt', 'e2fsprogs', 'sbin'))
+        Env.PrependENVPath('PATH', os.path.join(Prefix, 'opt', 'e2fsprogs', 'bin'))
+        Env.PrependENVPath('PATH', os.path.join(Prefix, 'opt', 'dosfstools', 'sbin'))
+        Env.PrependENVPath('PATH', os.path.join(Prefix, 'opt', 'make', 'libexec', 'gnubin'))
+        Env.PrependENVPath('PATH', os.path.join(Prefix, 'sbin'))
+        Env.PrependENVPath('PATH', os.path.join(Prefix, 'bin'))
+
+
+def ShouldUseRegularBuildTargets() -> bool:
+    Targets = set(COMMAND_LINE_TARGETS)
+    return not Targets or not Targets.issubset(SetupOnlyTargets)
+
+
+def ShouldRequireTargetToolchain() -> bool:
+    if GetOption('help') or GetOption('clean'):
+        return False
+    return ShouldUseRegularBuildTargets()
 
 
 def CreateHostEnvironment():
@@ -168,6 +194,14 @@ def CreateHostEnvironment():
         CFLAGS=['-std=c99'],
         STRIP='strip',
     )
+
+    AddHostToolPaths(Env)
+
+    ToolchainPrefixPath = ResolvePath(Env['ToolchainPrefix'])
+    Env['ToolchainPrefixPath'] = str(ToolchainPrefixPath)
+    ToolchainBinPath = ToolchainPrefixPath / 'bin'
+    if ToolchainBinPath.is_dir():
+        Env.PrependENVPath('PATH', str(ToolchainBinPath))
 
     Version = str(Env['ProjVersion'])
     if Env['BuildConfig'] == 'debug':
@@ -192,11 +226,69 @@ def CreateHostEnvironment():
     return Env
 
 
+def ResolveTools(Arch: str, ToolSearchPath: str):
+    ArchitectureConfig = GetArchConfig(Arch)
+    Prefixes = [
+        ArchitectureConfig.get('ToolchainPrefix', ''),
+        f'{Arch}-linux-musl-',
+        f'{Arch}-elf-',
+        '',
+    ]
+
+    UniquePrefixes = []
+    for Prefix in Prefixes:
+        if Prefix not in UniquePrefixes:
+            UniquePrefixes.append(Prefix)
+
+    Selected = ''
+    for Prefix in UniquePrefixes:
+        Gcc = f'{Prefix}gcc' if Prefix else 'gcc'
+        if shutil.which(Gcc, path=ToolSearchPath):
+            Selected = Prefix
+            break
+
+    Bases = {
+        'AS': 'as',
+        'AR': 'ar',
+        'CC': 'gcc',
+        'LD': 'gcc',
+        'RANLIB': 'ranlib',
+        'STRIP': 'strip',
+    }
+
+    Tools = {}
+    Paths = {}
+    Missing = []
+
+    for Key, Base in Bases.items():
+        Preferred = f'{Selected}{Base}' if Selected else Base
+        PreferredPath = shutil.which(Preferred, path=ToolSearchPath)
+        Tools[Key] = Preferred
+        Paths[Key] = PreferredPath or '<not found>'
+        if Selected and not PreferredPath:
+            Missing.append(Preferred)
+
+    if Missing:
+        MissingList = ', '.join(Missing)
+        print(f"Error: Cross-toolchain for {Arch} is incomplete. Missing: {MissingList}")
+        Exit(1)
+
+    return Tools, Paths, Selected
+
+
 def CreateTargetEnvironment(HostEnv):
     Arch = HostEnv['BuildArch']
     ArchitectureConfig = GetArchConfig(Arch)
 
-    Tools, ToolPaths, Prefix = ResolveTools(Arch)
+    Tools, ToolPaths, Prefix = ResolveTools(Arch, HostEnv['ENV'].get('PATH', os.environ['PATH']))
+    if ShouldRequireTargetToolchain() and not Prefix:
+        ExpectedPrefix = ArchitectureConfig.get('ToolchainPrefix', f'{Arch}-linux-musl-')
+        print(
+            f"Error: No cross-toolchain found for {Arch}. Expected {ExpectedPrefix}gcc "
+            f"on PATH or under {HostEnv['ToolchainPrefixPath']}/bin. "
+            "Run `scons toolchain` first, or set ToolchainPrefix=/path/to/toolchain."
+        )
+        Exit(1)
 
     Desc = Prefix if Prefix else 'unprefixed host tools'
     print(f"Using build tool prefix for {Arch}: {Desc}")
@@ -227,6 +319,126 @@ def CreateTargetEnvironment(HostEnv):
     return Env
 
 
+def GetImageType(Env):
+    return 'cdrom' if Env['ImageFormat'] == 'iso' else 'disk'
+
+
+def RunSubprocess(Command, Env):
+    return subprocess.call(Command, env=Env['ENV'])
+
+
+def RunDependenciesAction(target, source, env):
+    _ = (target, source)
+    Script = os.path.join('scripts', 'base', 'dependencies.py')
+    return RunSubprocess([sys.executable, Script, '-y'], env)
+
+
+def RunToolchainAction(target, source, env):
+    _ = (target, source)
+    Script = os.path.join('scripts', 'base', 'toolchain.py')
+    Command = [
+        sys.executable,
+        Script,
+        env['ToolchainPrefixPath'],
+        '-a',
+        env['BuildArch'],
+        '--ensure',
+    ]
+    return RunSubprocess(Command, env)
+
+
+def RunQemuAction(target, source, env):
+    _ = target
+    ImagePath = str(source[0])
+    Command = [
+        sys.executable,
+        os.path.join('scripts', 'base', 'qemu.py'),
+        GetImageType(env),
+        ImagePath,
+        '-a',
+        env['BuildArch'],
+        '-m',
+        env['RunMemory'],
+        '-s',
+        str(env['RunSmp']),
+    ]
+    return RunSubprocess(Command, env)
+
+
+def RunDebugAction(target, source, env):
+    _ = target
+    ImagePath = str(source[0])
+    KernelPath = str(source[1])
+    Command = [
+        sys.executable,
+        os.path.join('scripts', 'base', 'gdb.py'),
+        GetImageType(env),
+        ImagePath,
+        KernelPath,
+        '-a',
+        env['BuildArch'],
+        '-m',
+        env['RunMemory'],
+        '--gdb',
+        env['GdbCommand'],
+    ]
+    return RunSubprocess(Command, env)
+
+
+def FailRunAction(target, source, env):
+    _ = (target, source)
+    print(
+        "The `run` target requires BuildType=full or BuildType=image "
+        f"(current BuildType={env['BuildType']})."
+    )
+    return 1
+
+
+def FailDebugAction(target, source, env):
+    _ = (target, source)
+    print(
+        "The `debug` target requires BuildType=full or BuildType=image "
+        f"(current BuildType={env['BuildType']})."
+    )
+    return 1
+
+
+def RegisterPhonyTargets(Env, VariantDir):
+    DependenciesAlias = Env.Alias(
+        'deps',
+        [],
+        Action(RunDependenciesAction, '   DEPS    host packages'),
+    )
+    ToolchainAlias = Env.Alias(
+        'toolchain',
+        [],
+        Action(RunToolchainAction, '   TOOLCHAIN $ToolchainPrefixPath'),
+    )
+    AlwaysBuild(DependenciesAlias)
+    AlwaysBuild(ToolchainAlias)
+
+    ImageOutputName = (
+        f'{Env["ImageName"]}-{Env["ProjVersion"]}_'
+        f'{Env["BuildConfig"]}_{Env["BuildArch"]}.{Env["ImageFormat"]}'
+    )
+    ImageNode = Env.File(os.path.join(VariantDir, ImageOutputName))
+    KernelNode = Env.File(os.path.join(VariantDir, 'kernel', Env['KernelOutputName']))
+
+    if Env['BuildType'] in ('full', 'image'):
+        RunAlias = Env.Alias('run', [ImageNode], Action(RunQemuAction, '   RUN     $SOURCE'))
+        DebugAlias = Env.Alias(
+            'debug',
+            [ImageNode, KernelNode],
+            Action(RunDebugAction, '   DEBUG   $SOURCES'),
+        )
+    else:
+        RunAlias = Env.Alias('run', [], Action(FailRunAction, '   RUN     unavailable'))
+        DebugAlias = Env.Alias('debug', [], Action(FailDebugAction, '   DEBUG   unavailable'))
+
+    AlwaysBuild(RunAlias)
+    AlwaysBuild(DebugAlias)
+
+
 HostEnvironment = CreateHostEnvironment()
 TargetEnvironment = CreateTargetEnvironment(HostEnvironment)
 
@@ -244,14 +456,20 @@ StageDir = os.path.abspath(os.path.join(VariantDir, 'img'))
 TargetEnvironment['ImageStagingDirectory'] = StageDir
 TargetEnvironment['BootloaderComponents'] = {}
 
-if BuildType in ('full', 'usr', 'image'):
+RegisterPhonyTargets(TargetEnvironment, VariantDir)
+
+if ShouldUseRegularBuildTargets() and BuildType in ('full', 'usr', 'image'):
     SConscript('usr/SConscript', variant_dir=f'{VariantDir}/usr', duplicate=0)
 
-if BuildType in ('full', 'kernel', 'image'):
+if ShouldUseRegularBuildTargets() and BuildType in ('full', 'kernel', 'image'):
     SConscript('kernel/SConscript', variant_dir=f'{VariantDir}/kernel', duplicate=0)
 
-if BuildType in ('full', 'bootloader', 'image') and ShouldBuildSystemBootloader(BootSystem):
+if (
+    ShouldUseRegularBuildTargets()
+    and BuildType in ('full', 'bootloader', 'image')
+    and ShouldBuildSystemBootloader(BootSystem)
+):
     SConscript('bootloader/Sconscript', variant_dir=f'{VariantDir}/bootloader', duplicate=0)
 
-if BuildType in ('full', 'image'):
+if ShouldUseRegularBuildTargets() and BuildType in ('full', 'image'):
     SConscript('image/SConscript', variant_dir=VariantDir, duplicate=0)

--- a/image/SConscript
+++ b/image/SConscript
@@ -19,6 +19,7 @@ from scripts.scons.disk import (
     CreateBootableDisk,
     GenerateGrubConfig,
     GetPartitionTypeIdentifier,
+    PreflightImageTools,
 )
 
 Import('Kernel')
@@ -78,6 +79,8 @@ def BuildDisk(
     BootType = EnvironmentObject.get('BootType', 'bios')
     PartitionMap = EnvironmentObject.get('DiskPartitionMap', 'mbr')
     BuildConfig = EnvironmentObject.get('BuildConfig', 'release')
+
+    PreflightImageTools(OutputFormat, Filesystem, BootSystem, BootType, Architecture)
 
     Volume = VolumeLabel
     PartStartMb = 1
@@ -253,15 +256,21 @@ def BuildImageAction(*_Args, **KeywordArguments):
         and str(Src) not in BootloaderComponentSet
     ]
 
-    BuildDisk(
-        str(Target[0]),
-        KernelExecutablePath,
-        LibraryPaths,
-        ApplicationPaths,
-        ExtraFiles,
-        BootloaderComponentPaths,
-        EnvObj,
-    )
+    try:
+        BuildDisk(
+            str(Target[0]),
+            KernelExecutablePath,
+            LibraryPaths,
+            ApplicationPaths,
+            ExtraFiles,
+            BootloaderComponentPaths,
+            EnvObj,
+        )
+    except RuntimeError as Error:
+        print(f"Error: {Error}")
+        return 1
+
+    return 0
 
 
 Root = Env.Dir('root')

--- a/scripts/base/dependencies.py
+++ b/scripts/base/dependencies.py
@@ -9,6 +9,7 @@ Detects the Linux distribution and installs required packages.
 import argparse
 import multiprocessing
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -240,6 +241,45 @@ DEPENDENCIES = {
         'update_cmd': ['apk', 'update'],
         'install_cmd': ['apk', 'add'],
     },
+    'darwin': {
+        'packages': [
+            # === Core Build Tools ===
+            'python',
+            'scons',
+            'gcc',
+            'make',
+
+            # === Development Libraries (Required for Toolchain Build) ===
+            'gmp',
+            'mpfr',
+            'libmpc',
+            'zlib',
+
+            # === Filesystem & Disk Tools ===
+            'dosfstools',
+            'e2fsprogs',
+            'mtools',
+            'xorriso',
+
+            # === Boot & Image Creation ===
+            'i686-elf-grub',
+
+            # === Emulation & Debugging ===
+            'qemu',
+            'gdb',
+
+            # === Code Quality ===
+            'llvm',
+
+            # === Documentation ===
+            'pandoc',
+            'asciidoctor',
+            'texinfo',
+        ],
+        'update_cmd': ['brew', 'update'],
+        'install_cmd': ['brew', 'install'],
+        'use_sudo': False,
+    },
 }
 
 def get_cpu_count() -> int:
@@ -273,7 +313,10 @@ def extract_archive(archive: Path, dest_dir: Path):
         tar.extractall(str(dest_dir))
 
 def detect_distro() -> str:
-    """Detect the Linux distribution family."""
+    """Detect the host package-manager family."""
+    if platform.system() == 'Darwin':
+        return 'darwin'
+
     # Check for package managers
     if shutil.which('apt-get'):
         return 'debian'
@@ -325,9 +368,15 @@ def install_dependencies(distro: str, dry_run: bool = False,
     
     config = DEPENDENCIES[distro]
     packages = config['packages']
+    config_uses_sudo = config.get('use_sudo', True)
+
+    if distro == 'darwin' and not shutil.which('brew'):
+        print("Error: Homebrew is required for macOS dependency installation.", file=sys.stderr)
+        print("Install Homebrew from https://brew.sh/, then rerun this command.", file=sys.stderr)
+        return 1
     
     def run_cmd(cmd):
-        if use_sudo and os.geteuid() != 0:
+        if config_uses_sudo and use_sudo and os.geteuid() != 0:
             cmd = ['sudo'] + cmd
         
         print(f"$ {' '.join(cmd)}")

--- a/scripts/base/toolchain.py
+++ b/scripts/base/toolchain.py
@@ -169,6 +169,15 @@ class ToolchainBuilder:
     
     def _get_configure_opts(self, pkg: str) -> list:
         """Get platform-specific configure options."""
+        if detect_os() == 'Darwin':
+            if pkg == 'binutils':
+                return ['--with-system-zlib']
+            if pkg == 'gcc':
+                return [
+                    '--with-gmp=/opt/homebrew/opt/gmp',
+                    '--with-mpfr=/opt/homebrew/opt/mpfr',
+                    '--with-mpc=/opt/homebrew/opt/libmpc',
+                ]
         return []
     
     def build_binutils(self):

--- a/scripts/scons/disk.py
+++ b/scripts/scons/disk.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+import shutil
 import subprocess
 import textwrap
 
@@ -104,6 +105,169 @@ def GetGrubTarget(BootType: str, Architecture: str) -> str:
     return GrubTargetByBootAndArch[Key]
 
 
+def IsDarwin() -> bool:
+    return os.uname().sysname == 'Darwin'
+
+
+def GetHomebrewPrefixes() -> list:
+    Prefixes = []
+    EnvPrefix = os.environ.get('HOMEBREW_PREFIX')
+    if EnvPrefix:
+        Prefixes.append(EnvPrefix)
+    Prefixes.extend(['/opt/homebrew', '/usr/local'])
+
+    UniquePrefixes = []
+    for Prefix in Prefixes:
+        if Prefix not in UniquePrefixes:
+            UniquePrefixes.append(Prefix)
+    return UniquePrefixes
+
+
+def GetExecutableSearchPath() -> str:
+    Paths = os.environ.get('PATH', '').split(os.pathsep)
+    for Prefix in GetHomebrewPrefixes():
+        Paths.extend([
+            os.path.join(Prefix, 'bin'),
+            os.path.join(Prefix, 'sbin'),
+            os.path.join(Prefix, 'opt', 'make', 'libexec', 'gnubin'),
+            os.path.join(Prefix, 'opt', 'dosfstools', 'sbin'),
+            os.path.join(Prefix, 'opt', 'e2fsprogs', 'bin'),
+            os.path.join(Prefix, 'opt', 'e2fsprogs', 'sbin'),
+        ])
+
+    UniquePaths = []
+    for PathEntry in Paths:
+        if PathEntry and PathEntry not in UniquePaths:
+            UniquePaths.append(PathEntry)
+    return os.pathsep.join(UniquePaths)
+
+
+def FindExecutable(Candidates: list, EnvOverride: str = None) -> str:
+    SearchPath = GetExecutableSearchPath()
+    if EnvOverride:
+        Override = os.environ.get(EnvOverride)
+        if Override:
+            if os.path.isabs(Override) and os.path.exists(Override):
+                return Override
+            FoundOverride = shutil.which(Override, path=SearchPath)
+            if FoundOverride:
+                return FoundOverride
+
+    for Candidate in Candidates:
+        Found = shutil.which(Candidate, path=SearchPath)
+        if Found:
+            return Found
+
+    return None
+
+
+def RequireExecutable(
+    Candidates: list,
+    Purpose: str,
+    EnvOverride: str = None,
+    Suggestion: str = None,
+) -> str:
+    Found = FindExecutable(Candidates, EnvOverride)
+    if Found:
+        return Found
+
+    Names = ', '.join(Candidates)
+    Message = f"Missing required tool for {Purpose}: one of {Names}"
+    if EnvOverride:
+        Message += f" (or set {EnvOverride})"
+    if Suggestion:
+        Message += f". {Suggestion}"
+    raise RuntimeError(Message)
+
+
+def GetGrubMkimageCommand() -> str:
+    return RequireExecutable(
+        ['grub-mkimage', 'i686-elf-grub-mkimage', 'x86_64-elf-grub-mkimage'],
+        'GRUB image generation',
+        EnvOverride='GRUB_MKIMAGE',
+        Suggestion='Install GRUB tools, or set GRUB_MKIMAGE to the executable path.',
+    )
+
+
+def GetGrubMkrescueCommand() -> str:
+    return RequireExecutable(
+        ['grub-mkrescue', 'i686-elf-grub-mkrescue', 'x86_64-elf-grub-mkrescue'],
+        'GRUB rescue ISO generation',
+        EnvOverride='GRUB_MKRESCUE',
+        Suggestion='Install GRUB rescue tools, or set GRUB_MKRESCUE to the executable path.',
+    )
+
+
+def GetGrubPlatformDirectory(GrubTarget: str) -> str:
+    Candidates = []
+    Override = os.environ.get('GRUB_PLATFORM_DIR')
+    if Override:
+        Candidates.append(Override)
+
+    Candidates.extend([
+        os.path.join('/usr/lib/grub', GrubTarget),
+        os.path.join('/usr/local/lib/grub', GrubTarget),
+    ])
+
+    for Prefix in GetHomebrewPrefixes():
+        Candidates.extend([
+            os.path.join(Prefix, 'opt', 'i686-elf-grub', 'lib', 'i686-elf', 'grub', GrubTarget),
+            os.path.join(Prefix, 'opt', 'x86_64-elf-grub', 'lib', 'x86_64-elf', 'grub', GrubTarget),
+        ])
+
+    for Candidate in Candidates:
+        if os.path.exists(os.path.join(Candidate, 'boot.img')):
+            return Candidate
+
+    raise RuntimeError(
+        f"Could not find GRUB platform directory for {GrubTarget}. "
+        "Install GRUB platform files, or set GRUB_PLATFORM_DIR to the directory "
+        "containing boot.img."
+    )
+
+
+def PreflightImageTools(
+    OutputFormat: str,
+    Filesystem: str,
+    BootSystem: str,
+    BootType: str,
+    Architecture: str,
+):
+    if OutputFormat == 'iso':
+        if BootSystem == 'grub':
+            GetGrubMkrescueCommand()
+            RequireExecutable(
+                ['xorriso'],
+                'ISO generation',
+                Suggestion='Install xorriso before building ISO images.',
+            )
+        return
+
+    MacImageSuggestion = (
+        "On macOS, raw .img builds require guestfish. Build an ISO with "
+        "`scons ImageFormat=iso`, or build raw disk images in Linux or a Linux container."
+        if IsDarwin()
+        else 'Install guestfish/libguestfs before building raw disk images.'
+    )
+
+    RequireExecutable(['truncate'], 'raw disk image sizing')
+    RequireExecutable(['dd'], 'raw disk image writing')
+    RequireExecutable(
+        ['guestfish'],
+        'raw disk image partitioning and file injection',
+        Suggestion=MacImageSuggestion,
+    )
+    RequireExecutable(
+        [GetFilesystemConfig(Filesystem)['MakeFilesystemCommand']],
+        f'{Filesystem} filesystem creation',
+    )
+
+    if BootSystem == 'grub':
+        GetGrubMkimageCommand()
+        if BootType == 'bios':
+            GetGrubPlatformDirectory(GetGrubTarget(BootType, Architecture))
+
+
 def GetEfiDefaultBinaryName(Architecture: str) -> str:
     if Architecture not in EfiDefaultBinaryByArch:
         raise ValueError(f"Unsupported EFI architecture: {Architecture}")
@@ -154,9 +318,13 @@ def RunCommand(Arguments: list, InputText: str = None):
 
 def FormatPartitionImage(PartitionPath: str, Filesystem: str, VolumeLabelName: str = VolumeLabel):
     FilesystemConfig = GetFilesystemConfig(Filesystem)
-    MakeFilesystemCommand = FilesystemConfig['MakeFilesystemCommand']
+    MakeFilesystemName = FilesystemConfig['MakeFilesystemCommand']
+    MakeFilesystemCommand = RequireExecutable(
+        [MakeFilesystemName],
+        f'{Filesystem} filesystem creation',
+    )
 
-    if MakeFilesystemCommand == 'mkfs.fat':
+    if MakeFilesystemName == 'mkfs.fat':
         RunCommand([
             MakeFilesystemCommand,
             *FilesystemConfig['MakeFilesystemArguments'],
@@ -164,7 +332,7 @@ def FormatPartitionImage(PartitionPath: str, Filesystem: str, VolumeLabelName: s
             VolumeLabelName,
             PartitionPath,
         ])
-    elif MakeFilesystemCommand == 'mkfs.ext2':
+    elif MakeFilesystemName == 'mkfs.ext2':
         RunCommand([MakeFilesystemCommand, '-L', VolumeLabelName, PartitionPath])
     else:
         raise ValueError(
@@ -183,7 +351,15 @@ def CreateBootableIso(StagingDirectory: str, OutputIso: str, VolumeLabelName: st
         VolumeLabelName: ISO volume label
     """
     print("   GRUB-MKRESCUE")
-    RunCommand(['grub-mkrescue', '-o', OutputIso, StagingDirectory, '--', '-volid', VolumeLabelName])
+    RunCommand([
+        GetGrubMkrescueCommand(),
+        '-o',
+        OutputIso,
+        StagingDirectory,
+        '--',
+        '-volid',
+        VolumeLabelName,
+    ])
 
 
 def CreateBootableDisk(
@@ -214,13 +390,14 @@ def CreateBootableDisk(
 
     if BootSystem == 'grub':
         GrubTarget = GetGrubTarget(BootType, Architecture)
-        GrubPath = os.path.join('/usr/lib/grub', GrubTarget)
         GrubPrefix = GetGrubPrefix(PartitionMap)
+        GrubMkimage = GetGrubMkimageCommand()
 
         print("   GRUB-MKIMAGE")
         if BootType == 'bios':
+            GrubPath = GetGrubPlatformDirectory(GrubTarget)
             RunCommand([
-                'grub-mkimage',
+                GrubMkimage,
                 '-O', GrubTarget,
                 '-o', GrubCore,
                 '-p', GrubPrefix,
@@ -237,7 +414,7 @@ def CreateBootableDisk(
             os.makedirs(EfiDirectory, exist_ok=True)
             GeneratedEfiBinary = os.path.join(EfiDirectory, GetEfiDefaultBinaryName(Architecture))
             RunCommand([
-                'grub-mkimage',
+                GrubMkimage,
                 '-O', GrubTarget,
                 '-o', GeneratedEfiBinary,
                 '-p', GrubPrefix,


### PR DESCRIPTION
## Summary
- add real SCons aliases for deps, toolchain, run, and debug
- prefer the managed local cross-toolchain and report missing toolchains clearly
- harden GRUB/image tool discovery for Linux and macOS, including clean guestfish guidance
- add Homebrew dependency support and refresh build documentation

## Why
The documented contributor workflow referenced commands that were not wired into SCons, and macOS raw image builds failed late with an unclear guestfish error. This makes the workflow executable and gives platform-specific guidance when host tooling is missing.

## Validation
- scons toolchain
- scons BuildType=kernel
- scons BuildType=usr
- scons ImageFormat=iso
- python3 scripts/base/dependencies.py -n --no-sudo
- python3 scripts/base/dependencies.py -d debian -n --no-sudo
- scons -n run ImageFormat=iso RunMemory=512M RunSmp=2
- scons --help
- scons (expected macOS failure: missing guestfish for raw .img, with clear ImageFormat=iso guidance)
