### PR TITLE
preflight linux image build tools

### DIFF
--- a/image/SConscript
+++ b/image/SConscript
@@ -19,6 +19,7 @@ from scripts.scons.disk import (
     CreateBootableDisk,
     GenerateGrubConfig,
     GetPartitionTypeIdentifier,
+    PreflightImageTools,
 )
 
 Import('Kernel')
@@ -78,6 +79,14 @@ def BuildDisk(
     BootType = EnvironmentObject.get('BootType', 'bios')
     PartitionMap = EnvironmentObject.get('DiskPartitionMap', 'mbr')
     BuildConfig = EnvironmentObject.get('BuildConfig', 'release')
+
+    PreflightImageTools(
+        OutputFormat,
+        Filesystem,
+        BootSystem,
+        BootType,
+        Architecture,
+    )
 
     Volume = VolumeLabel
     PartStartMb = 1
@@ -253,15 +262,21 @@ def BuildImageAction(*_Args, **KeywordArguments):
         and str(Src) not in BootloaderComponentSet
     ]
 
-    BuildDisk(
-        str(Target[0]),
-        KernelExecutablePath,
-        LibraryPaths,
-        ApplicationPaths,
-        ExtraFiles,
-        BootloaderComponentPaths,
-        EnvObj,
-    )
+    try:
+        BuildDisk(
+            str(Target[0]),
+            KernelExecutablePath,
+            LibraryPaths,
+            ApplicationPaths,
+            ExtraFiles,
+            BootloaderComponentPaths,
+            EnvObj,
+        )
+    except RuntimeError as Error:
+        print(f"Error: {Error}")
+        return 1
+
+    return 0
 
 
 Root = Env.Dir('root')

--- a/scripts/scons/disk.py
+++ b/scripts/scons/disk.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
+import shutil
 import subprocess
 import textwrap
 
@@ -150,6 +151,71 @@ def RunCommand(Arguments: list, InputText: str = None):
         input=InputText,
         text=(InputText is not None),
     )
+
+
+def DockerBuilderHint() -> str:
+    return (
+        'Use the Docker builder image instead: '
+        'docker run --rm -v "$PWD:/build" -w /build '
+        'vincent4486/valeciumos-builder:i686 scons ...'
+    )
+
+
+def RequireExecutable(Name: str, Purpose: str):
+    if shutil.which(Name):
+        return
+    raise RuntimeError(
+        f'Missing required image build tool `{Name}` for {Purpose}. '
+        f'{DockerBuilderHint()}'
+    )
+
+
+def RequirePath(Path: str, Purpose: str):
+    if os.path.exists(Path):
+        return
+    raise RuntimeError(
+        f'Missing required image build path `{Path}` for {Purpose}. '
+        f'{DockerBuilderHint()}'
+    )
+
+
+def PreflightImageTools(
+    OutputFormat: str,
+    Filesystem: str,
+    BootSystem: str,
+    BootType: str,
+    Architecture: str,
+):
+    if OutputFormat == 'iso':
+        if BootSystem == 'grub':
+            RequireExecutable('xorriso', 'GRUB ISO creation')
+            RequireExecutable('grub-mkrescue', 'GRUB ISO creation')
+        return
+
+    if OutputFormat != 'img':
+        return
+
+    FilesystemConfig = GetFilesystemConfig(Filesystem)
+    RequireExecutable('guestfish', 'raw disk image partitioning and file injection')
+    RequireExecutable(
+        FilesystemConfig['MakeFilesystemCommand'],
+        f'{Filesystem} partition formatting',
+    )
+
+    if BootSystem != 'grub':
+        return
+
+    GrubTarget = GetGrubTarget(BootType, Architecture)
+    GrubPath = os.path.join('/usr/lib/grub', GrubTarget)
+
+    RequireExecutable('grub-mkimage', 'GRUB disk image bootloader creation')
+    RequirePath(GrubPath, f'GRUB target {GrubTarget}')
+
+    if BootType == 'bios':
+        RequirePath(
+            os.path.join(GrubPath, 'boot.img'),
+            f'GRUB BIOS target {GrubTarget}',
+        )
 
 
 def FormatPartitionImage(PartitionPath: str, Filesystem: str, VolumeLabelName: str = VolumeLabel):


### PR DESCRIPTION
## Summary
- preflight required Linux image tools before image generation
- check `.img` requirements such as `guestfish`, filesystem formatter, `grub-mkimage`, and `/usr/lib/grub/<target>` where applicable
- check `.iso` requirements such as `xorriso` and `grub-mkrescue`
- return plain SCons build errors for missing tools instead of late command failures or tracebacks

## Intentionally excluded
- no Homebrew or Darwin fallback paths
- no automatic image format switching
- no SCons run/debug/deps/toolchain aliases

## Validation
- `docker run --rm -v "$PWD:/build" -w /build vincent4486/valeciumos-builder:i686 scons -Q BuildArch=i686 BuildType=image ImageFormat=img`
- `docker run --rm -v "$PWD:/build" -w /build vincent4486/valeciumos-builder:i686 scons -Q BuildArch=i686 BuildType=image ImageFormat=iso`
- Disposable-container negative test with `xorriso` removed from `PATH` fails early with: `Missing required image build tool `xorriso` for GRUB ISO creation`
