### PR TITLE
harden i686 hardware boot path

### DIFF
--- a/kernel/SConscript
+++ b/kernel/SConscript
@@ -37,12 +37,15 @@ Env.Append(
         '-ffreestanding',       # No hosted environment
         '-nostdlib',            # No standard library (kernel-only)
         '-fno-stack-protector', # No stack protection (requires libc)
+        '-fno-pic',             # No GOT/PLT indirection in early kernel code
+        '-fno-pie',             # Build a fixed-address kernel image
         '-fno-builtin',         # Don't use compiler builtin replacements for libc functions
         '-Wall',
         '-Wextra',
     ],
     LINKFLAGS=[
         '-nostdlib',
+        '-no-pie',
         '-Wl,-T', LinkerScript,
         '-Wl,-Map=' + Env.File('kernel.map').path,
         '-Wl,-z,relro,-z,now',   # Security: read-only relocations

--- a/kernel/arch/i686/boot/entry.S
+++ b/kernel/arch/i686/boot/entry.S
@@ -16,6 +16,8 @@
 .global _start
 .extern Parser_Multiboot
 
+.equ BOOTSTRAP_STACK_TOP, 0x90000
+
 _start:
 	# GRUB/Multiboot passes: EAX = 0x2BADB002 (magic), EBX = *multiboot_info_t
     cmpl $0x2BADB002, %eax
@@ -25,8 +27,19 @@ _start:
     movl %eax, %edi         # edi = magic   (1st argument to Parser_Multiboot)
     movl %ebx, %esi         # esi = mbi ptr (2nd argument to Parser_Multiboot)
 
+	# Enter C with known flat data segments.  Multiboot enters protected
+	# mode with SS holding a valid data selector; copy that selector rather
+	# than assuming a specific bootloader GDT index.
+	cld
+	movw %ss, %ax
+	movw %ax, %ds
+	movw %ax, %es
+	movw %ax, %fs
+	movw %ax, %gs
+	movw %ax, %ss
+
 	# Set up a small temporary stack (below the 640 KB low-memory mark).
-    movl $0x90000, %esp
+    movl $BOOTSTRAP_STACK_TOP, %esp
     movl %esp, %ebp
 
 	# Push arguments in cdecl right-to-left order:

--- a/kernel/arch/i686/linker.ld
+++ b/kernel/arch/i686/linker.ld
@@ -22,6 +22,8 @@ PHDRS
 /* Default kernel load address (override with --defsym=KERNEL_LOAD_ADDR=...) */
 KERNEL_LOAD_ADDR = DEFINED(KERNEL_LOAD_ADDR) ? KERNEL_LOAD_ADDR : 0x00100000;
 phys = KERNEL_LOAD_ADDR;
+BOOTSTRAP_STACK_BOTTOM = 0x00080000;
+BOOTSTRAP_STACK_TOP = 0x00090000;
 
 /* Allow undefined symbols - they will be resolved at runtime by dylib loader */
 /* This lets kernel code call library functions without explicit EXTERN declarations */
@@ -68,7 +70,10 @@ SECTIONS
     
     .rel.plt            : { _kernel_rel_plt_start = .; *(.rel.plt) _kernel_rel_plt_end = .; }
     
-    .bss                : ALIGN(1024) { __bss_start = .;        *(.bss .bss.*)     }
+    .bss                : ALIGN(4096) { __bss_start = .;        *(.bss .bss.*)     }
     
     __end = .;
+
+    ASSERT(__end <= BOOTSTRAP_STACK_BOTTOM || __bss_start >= BOOTSTRAP_STACK_TOP,
+           "kernel BSS overlaps the reserved bootstrap stack")
 }

--- a/kernel/arch/i686/mem/paging.c
+++ b/kernel/arch/i686/mem/paging.c
@@ -8,7 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-extern uint8_t __end; // provided by linker, end of kernel image
+extern uint8_t __end[]; // provided by linker, end of kernel image
 
 #define PAGE_TABLE_ENTRIES 1024
 #define PAGE_DIR_ENTRIES 1024
@@ -71,7 +71,7 @@ static uint32_t alloc_frame(void)
    // Fallback bump allocator (early bootstrap only)
    if (!phys_alloc_ptr)
    {
-      phys_alloc_ptr = align_up((uintptr_t)&__end, PAGE_SIZE);
+      phys_alloc_ptr = align_up((uintptr_t)__end, PAGE_SIZE);
    }
 
    // Cap to 256MB to avoid wrap/overlap; this is a soft guard for early use.

--- a/kernel/arch/i686/mem/vm_layout.h
+++ b/kernel/arch/i686/mem/vm_layout.h
@@ -6,7 +6,7 @@
 #include <mem/mm_kernel.h>
 #include <stdint.h>
 
-extern uint8_t __end;
+extern uint8_t __end[];
 
 /** Kernel base address - identity mapped at 3GB (0xC0000000) */
 #define KERNEL_BASE 0xC0000000UL

--- a/kernel/init/main.c
+++ b/kernel/init/main.c
@@ -15,7 +15,6 @@
 #include <hal/video.h>
 #include <mem/mm_kernel.h>
 #include <std/stdio.h>
-#include <std/string.h>
 #include <stdint.h>
 #include <sys/cmdline.h>
 #include <sys/elf.h>
@@ -28,9 +27,38 @@ extern int Init_MountRoot(void);
 extern void interact();
 static void __attribute__((unused, noreturn)) fallback(void);
 
-extern uint8_t __bss_start;
-extern uint8_t __end;
+extern uint8_t __bss_start[];
+extern uint8_t __end[];
 extern void _init();
+
+static void clear_memory(void *base, uintptr_t size)
+{
+   volatile uint8_t *ptr = (volatile uint8_t *)base;
+   while (size > 0)
+   {
+      *ptr = 0;
+      ptr++;
+      size--;
+   }
+}
+
+static void copy_memory(void *dest, const void *src, uintptr_t size)
+{
+   uint8_t *dest_ptr = (uint8_t *)dest;
+   const uint8_t *src_ptr = (const uint8_t *)src;
+   while (size > 0)
+   {
+      *dest_ptr = *src_ptr;
+      dest_ptr++;
+      src_ptr++;
+      size--;
+   }
+}
+
+static void clear_bss(void)
+{
+   clear_memory(__bss_start, (uintptr_t)(__end - __bss_start));
+}
 
 void hold(int sec)
 {
@@ -62,17 +90,14 @@ void hold(int sec)
 void __attribute__((noreturn)) start(BOOT_Info *boot)
 {
    BOOT_Info boot_snapshot;
+   clear_memory(&boot_snapshot, sizeof(boot_snapshot));
    if (boot)
    {
-      boot_snapshot = *boot;
-   }
-   else
-   {
-      memset(&boot_snapshot, 0, sizeof(boot_snapshot));
+      copy_memory(&boot_snapshot, boot, sizeof(boot_snapshot));
    }
 
-   memset(&__bss_start, 0, (&__end) - (&__bss_start));
-   memset(g_SysInfo, 0, sizeof(SYS_Info));
+   clear_bss();
+   clear_memory(g_SysInfo, sizeof(SYS_Info));
 
    g_SysInfo->boot = boot_snapshot;
 

--- a/kernel/mem/heap.c
+++ b/kernel/mem/heap.c
@@ -8,7 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-extern uint8_t __end; /* linker-provided end of kernel image */
+extern uint8_t __end[]; /* linker-provided end of kernel image */
 
 /* Simple bump allocator state */
 static uintptr_t heap_start = 0;
@@ -118,7 +118,7 @@ static uintptr_t align_up(uintptr_t v, size_t align)
 void Heap_Initialize(void)
 {
    /* place heap just after the kernel image end symbol */
-   heap_start = align_up((uintptr_t)&__end, 8);
+   heap_start = align_up((uintptr_t)__end, 8);
 
    /* Set heap to a reasonable size - 64 MiB should be plenty for a kernel */
    const uintptr_t heap_size = 64 * 1024 * 1024u; // 64 MiB

--- a/kernel/mem/memory.c
+++ b/kernel/mem/memory.c
@@ -10,8 +10,8 @@
 #include <stdint.h>
 #include <sys/sys.h>
 
-extern uint8_t __kernel_image_start;
-extern uint8_t __end;
+extern uint8_t __kernel_image_start[];
+extern uint8_t __end[];
 
 /* Runtime-controlled memory debug flag. Set non-zero to make the handler
  * call `i686_Panic()` when a memory safety fault is detected. Default is 0.
@@ -192,8 +192,8 @@ void MEM_Initialize(void)
    /* Populate memory info in SYS_Info */
    g_SysInfo->memory.total_memory = total_memory;
    g_SysInfo->memory.page_size = HAL_ARCH_PAGE_SIZE;
-   g_SysInfo->memory.kernel_start = (uint32_t)(uintptr_t)&__kernel_image_start;
-   g_SysInfo->memory.kernel_end = (uint32_t)(uintptr_t)&__end;
+   g_SysInfo->memory.kernel_start = (uint32_t)(uintptr_t)__kernel_image_start;
+   g_SysInfo->memory.kernel_end = (uint32_t)(uintptr_t)__end;
    g_SysInfo->memory.user_start = (uint32_t)HAL_ARCH_CODE_START;
    g_SysInfo->memory.user_end = (uint32_t)HAL_ARCH_SPACE_END;
    g_SysInfo->memory.kernel_stack_size = 65536; /* 64KB kernel stack */

--- a/kernel/mem/mm_kernel.h
+++ b/kernel/mem/mm_kernel.h
@@ -198,10 +198,10 @@ int Stack_SelfTest(void);
 /* Architecture page size (4 KiB) */
 #define PAGE_SIZE 0x1000u
 
-extern uint8_t __kernel_image_start;
+extern uint8_t __kernel_image_start[];
 
 /* Linker-defined kernel image start; avoids raw fixed literals in C code. */
-#define MEMORY_KERNEL_ADDR ((void *)&__kernel_image_start)
+#define MEMORY_KERNEL_ADDR ((void *)__kernel_image_start)
 
 /* Library registry entries (storage owned by kmod.c in kernel memory). */
 #define LIB_NAME_MAX 32

--- a/kernel/sys/kmod/kmod.c
+++ b/kernel/sys/kmod/kmod.c
@@ -212,6 +212,8 @@ void KMOD_ClearGlobalSymtab(void)
 // Relocation Application
 // ============================================================================
 
+#define KERNEL_RELOCATION_WINDOW_BYTES 0x01000000u
+
 // Apply relocations to a loaded library or to the kernel
 // Returns 0 on success, -1 on unresolved symbols
 static int apply_relocations(uint32_t base, Elf32_Rel *rel_table,
@@ -237,11 +239,10 @@ static int apply_relocations(uint32_t base, Elf32_Rel *rel_table,
 
       /* Verify target falls within expected area for this base. This avoids
        * writing to clearly invalid low addresses when the relocation entry
-       * already contains an absolute virtual address. We allow a large
-       * permitted range (1 MiB..+16 MiB) relative to base to be tolerant.
+       * already contains an absolute virtual address.
        */
       uint32_t allowed_low = base;
-      uint32_t allowed_high = base + 0x0100000; /* 1 MiB window */
+      uint32_t allowed_high = base + KERNEL_RELOCATION_WINDOW_BYTES;
       if (r_offset < allowed_low || r_offset > allowed_high)
       {
          logfmt(LOG_ERROR,
@@ -355,9 +356,9 @@ int KMOD_ApplyKernelRelocations(void)
    extern char _kernel_rel_plt_end[];
    extern char _kernel_dynsym_start[];
    extern char _kernel_dynstr_start[];
-   extern uint8_t __kernel_image_start;
+   extern uint8_t __kernel_image_start[];
 
-   uint32_t kernel_base = (uint32_t)(uintptr_t)&__kernel_image_start;
+   uint32_t kernel_base = (uint32_t)(uintptr_t)__kernel_image_start;
 
    // Apply .rel.dyn relocations
    {


### PR DESCRIPTION
## Summary
- harden the i686 Multiboot entry path so C starts with a consistent data-segment state
- make early BSS clearing independent of runtime/library calls and use array-form linker symbols
- page-align kernel BSS, assert that it cannot overlap the reserved bootstrap stack, and build the kernel as non-PIC/non-PIE
- expand the kernel relocation acceptance window from 1 MiB to 16 MiB

Closes #69.

## Notes
The issue suggested loading selector `0x10` directly in `entry.S`. Testing showed GRUB entered this kernel with `ss=0x18`; forcing `0x10` caused a protected-mode GPF at the `ss` reload. This PR instead copies the valid Multiboot data selector from `ss` into `ds/es/fs/gs/ss`, which keeps the entry state explicit without assuming the bootloader's GDT indexes.

## Validation
Docker builder validation using `vincent4486/valeciumos-builder:i686` with `PATH=/opt/cross/bin:$PATH`:

- clean rebuild: `scons -Q BuildArch=i686 BuildType=kernel`
- clean rebuild: `scons -Q BuildArch=i686 BuildType=usr`
- clean rebuild: `scons -Q BuildArch=i686 BuildType=image ImageFormat=img`
- clean rebuild: `scons -Q BuildArch=i686 BuildType=image ImageFormat=iso`
- `i686-linux-musl-readelf -r build/i686_debug/kernel/valeciumx-0.28` reports no relocations
- `i686-linux-musl-readelf -S build/i686_debug/kernel/valeciumx-0.28` reports `.bss` alignment `4096`
- `kernel.map` reports `__bss_start=0x00127000`, `__end=0x001c7048`, and the bootstrap-stack overlap assertion passes
- built artifacts: kernel ELF `454K`, raw image `250M`, ISO `16M`

Host QEMU validation:

- raw image booted with `qemu-system-i386 -drive file=build/i686_debug/valeciumos-0.28_debug_i686.img,format=raw,if=ide`
- ISO booted with `qemu-system-i386 -cdrom build/i686_debug/valeciumos-0.28_debug_i686.iso`
- both QEMU exception logs were checked for `Triple fault`, `check_exception`, `v=0d`, `v=06`, and invalid-opcode indicators; none were present
- raw image reached system finalization and the stdin self-test prompt
- ISO reached normal kernel filesystem/root-mount error handling without early CPU faults

86Box setup:

- installed 86Box 5.3 via Homebrew cask
- installed current 86Box ROM set into `~/Library/Application Support/net.86box.86Box/roms`

## Not validated automatically
- 86Box boot remains manual GUI validation. The app and ROMs are installed, but this environment does not expose a stable CLI boot path that I can use as an automated smoke test.
